### PR TITLE
Bugfix/UX: Restrict Module Workers warning to Firefox < 114

### DIFF
--- a/js/browser-compat-abort.js
+++ b/js/browser-compat-abort.js
@@ -12,10 +12,12 @@ if (regex.test(browserName)) {
   const [ , ff, version] = browserName.match(regex);
   if (ff !== null) {
     if (parseFloat(version) >= 111) {
-      const mode = localStorage.getItem("hideFFNotification") || "false";
-      if (mode === "false") {
-        const res = confirm(changeFirefoxConfig) || false;
-        localStorage.setItem("hideFFNotification", res);
+      if (parseFloat(version) < 114) {
+        const mode = localStorage.getItem("hideFFNotification") || "false";
+        if (mode === "false") {
+          const res = confirm(changeFirefoxConfig) || false;
+          localStorage.setItem("hideFFNotification", res);
+        }
       }
     } else {
       document.body.innerHTML = oldFirefoxBad;


### PR DESCRIPTION
Module Workers has been enabled by default since Firefox 114 [1]. The about:config option mentioned in the warning has been removed since Firefox 132 [2].

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1812591
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1880789